### PR TITLE
using quay.io image override

### DIFF
--- a/deploy/olm-catalog/knative-kafka-operator/0.6.0/knative-kafka-operator.v0.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-kafka-operator/0.6.0/knative-kafka-operator.v0.6.0.clusterserviceversion.yaml
@@ -91,6 +91,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-kafka-operator
                 image: quay.io/openshift-knative/knative-kafka-operator:v0.6.0
+                args:
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.6.0/openshift/release/knative-eventing-kafka-v0.6.0.yaml,https://raw.githubusercontent.com/openshift/knative-eventing-sources/release-v0.6.0/openshift/release/knative-eventing-kafka-sources-v0.6.0.yaml
                 imagePullPolicy: Always
                 name: knative-kafka-operator
                 resources: {}


### PR DESCRIPTION
Override the embedded resource yamls, pointing to our own quay.io images, like we do on all other operators for our knative offerings

@syedriko  once merged, you need to run the `./hack/release.sh` script.

After that, please update your "operator-framework/community-operators" PR as well. 
