### PR TITLE
Adding override for quay.io images for 0.9.0

### DIFF
--- a/deploy/olm-catalog/knative-kafka-operator/0.9.0/knative-kafka-operator.v0.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-kafka-operator/0.9.0/knative-kafka-operator.v0.9.0.clusterserviceversion.yaml
@@ -95,6 +95,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-kafka-operator
                 image: quay.io/openshift-knative/knative-kafka-operator:v0.9.0
+                args:
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.9.0/openshift/release/knative-eventing-kafka-contrib-v0.9.0.yaml
                 imagePullPolicy: Always
                 name: knative-kafka-operator
                 resources: {}


### PR DESCRIPTION
Adding override for quay.io images, so that we deploy our own built images, instead of the community ones

