### PR TITLE
Adding produized image release yaml, and required NetworkPolicy

### DIFF
--- a/deploy/olm-catalog/knative-kafka-operator/0.11.2/knative-kafka-operator.v0.11.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-kafka-operator/0.11.2/knative-kafka-operator.v0.11.2.clusterserviceversion.yaml
@@ -95,6 +95,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-kafka-operator
                 image: quay.io/openshift-knative/knative-kafka-operator:v0.11.2
+                args:
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.11.2/openshift/release/knative-eventing-kafka-contrib-v0.11.2.yaml,https://raw.githubusercontent.com/openshift-knative/knative-kafka-operator/master/deploy/resources/networkpolicies.yaml
                 imagePullPolicy: Always
                 name: knative-kafka-operator
                 resources: {}

--- a/deploy/olm-catalog/knative-kafka-operator/0.11.2/knative-kafka-operator.v0.11.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-kafka-operator/0.11.2/knative-kafka-operator.v0.11.2.clusterserviceversion.yaml
@@ -96,7 +96,7 @@ spec:
                   value: knative-kafka-operator
                 image: quay.io/openshift-knative/knative-kafka-operator:v0.11.2
                 args:
-                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.11.2/openshift/release/knative-eventing-kafka-contrib-v0.11.2.yaml,https://raw.githubusercontent.com/openshift-knative/knative-kafka-operator/master/deploy/resources/networkpolicies.yaml
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.11.2/openshift/release/knative-eventing-kafka-contrib-v0.11.2.yaml,https://raw.githubusercontent.com/openshift-knative/knative-kafka-operator/v0.11.2/deploy/resources/networkpolicies.yaml
                 imagePullPolicy: Always
                 name: knative-kafka-operator
                 resources: {}


### PR DESCRIPTION
 this will override the files in the deploy/resources folder. That way we ensure that our Operator really ships our own quay.io based images, and potential fixes that are made for openshift in the referenced 'release' file