### PR TITLE
removing NetworkPolicy override uRL

### DIFF
--- a/deploy/olm-catalog/knative-kafka-operator/0.12.1/knative-kafka-operator.v0.12.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-kafka-operator/0.12.1/knative-kafka-operator.v0.12.1.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ spec:
                   value: knative-kafka-operator
                 image: quay.io/openshift-knative/knative-kafka-operator:v0.12.1
                 args:
-                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.12.1/openshift/release/knative-eventing-kafka-contrib-v0.12.1.yaml,https://raw.githubusercontent.com/openshift-knative/knative-kafka-operator/v0.12.1/deploy/resources/networkpolicies.yaml
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing-contrib/release-v0.12.1/openshift/release/knative-eventing-kafka-contrib-v0.12.1.yaml
                 imagePullPolicy: Always
                 name: knative-kafka-operator
                 resources: {}


### PR DESCRIPTION
, since Serverless is now on Kourier / 1.5.0

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>