### PR TITLE
patch the webhook value

### DIFF
--- a/deploy/resources/knative-eventing-kafka-contrib-v0.14.1.yaml
+++ b/deploy/resources/knative-eventing-kafka-contrib-v0.14.1.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: knative-sources
+  name: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: devel
 ---
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: devel
 ---
@@ -103,7 +103,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -118,7 +118,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -321,7 +321,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kafka-controller
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: devel
     control-plane: kafka-controller-manager
@@ -336,7 +336,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: devel
     control-plane: kafka-controller-manager
@@ -381,7 +381,7 @@ metadata:
     role: webhook
     contrib.eventing.knative.dev/release: devel
   name: kafka-source-webhook
-  namespace: knative-sources
+  namespace: knative-eventing
 spec:
   ports:
     - port: 443
@@ -445,7 +445,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kafka-source-webhook-certs
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: devel
 ---
@@ -453,7 +453,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election-kafka
-  namespace: knative-sources
+  namespace: knative-eventing
 data:
   resourceLock: "leases"
   leaseDuration: "15s"

--- a/deploy/resources/knative-eventing-kafka-contrib-v0.14.1.yaml
+++ b/deploy/resources/knative-eventing-kafka-contrib-v0.14.1.yaml
@@ -401,7 +401,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: defaulting.webhook.kafka.sources.knative.dev
 ---
@@ -417,7 +417,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: validation.webhook.kafka.sources.knative.dev
 ---
@@ -433,7 +433,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: config.webhook.kafka.sources.knative.dev
   namespaceSelector:


### PR DESCRIPTION
Set the value to knative-eventing, like on channel webhook. this is only a work-around, since the operator (for both: channel/source) does never override those to the 'real' namespace

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

/assign @aliok 